### PR TITLE
API Overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 vendor/
 .idea
+.project
+.buildpath
+.settings/

--- a/configuration/routes.yml
+++ b/configuration/routes.yml
@@ -5,6 +5,20 @@ api_authenticate:
     parameters: [ ]
     csrf_enabled: false
 
+api_status:
+    route: /api/:api_username/status/:format
+    module: remote
+    action: status
+    parameters: [ ]
+    csrf_enabled: false
+
+api_me:
+    route: /api/:api_username/me/:format
+    module: remote
+    action: me
+    parameters: [ ]
+    csrf_enabled: false
+
 api_list_projects:
     route: /api/:api_username/projects/:format
     module: remote

--- a/configuration/routes.yml
+++ b/configuration/routes.yml
@@ -6,42 +6,42 @@ api_authenticate:
     csrf_enabled: false
 
 api_status:
-    route: /api/:api_username/status/:format
+    route: /api/:api_username/status
     module: api
     action: status
     parameters: [ ]
     csrf_enabled: false
 
 api_me:
-    route: /api/:api_username/me/:format
+    route: /api/:api_username/me
     module: api
     action: me
     parameters: [ ]
     csrf_enabled: false
 
 api_list_projects:
-    route: /api/:api_username/projects/:format
+    route: /api/:api_username/projects
     module: api
     action: listProjects
     parameters: [ ]
     csrf_enabled: false
 
 api_list_issuetypes:
-    route: /api/:api_username/issuetypes/:format
+    route: /api/:api_username/issuetypes
     module: api
     action: listIssuetypes
     parameters: [ ]
     csrf_enabled: false
 
 api_list_issuefields:
-    route: /api/:api_username/list/issuefields/for/:project_key/type/:issuetype/:format
+    route: /api/:api_username/list/issuefields/for/:project_key/type/:issuetype
     module: api
     action: listIssuefields
     parameters: [ ]
     csrf_enabled: false
 
 api_list_fieldvalues:
-    route: '/api/:api_username/list/fieldvalues/for/field/:field_key/:format/*'
+    route: '/api/:api_username/list/fieldvalues/for/field/:field_key/*'
     module: api
     action: listFieldvalues
     parameters: [ ]

--- a/configuration/routes.yml
+++ b/configuration/routes.yml
@@ -1,48 +1,48 @@
 api_authenticate:
     route: /api/authenticate/:username
-    module: remote
+    module: api
     action: authenticate
     parameters: [ ]
     csrf_enabled: false
 
 api_status:
     route: /api/:api_username/status/:format
-    module: remote
+    module: api
     action: status
     parameters: [ ]
     csrf_enabled: false
 
 api_me:
     route: /api/:api_username/me/:format
-    module: remote
+    module: api
     action: me
     parameters: [ ]
     csrf_enabled: false
 
 api_list_projects:
     route: /api/:api_username/projects/:format
-    module: remote
+    module: api
     action: listProjects
     parameters: [ ]
     csrf_enabled: false
 
 api_list_issuetypes:
     route: /api/:api_username/issuetypes/:format
-    module: remote
+    module: api
     action: listIssuetypes
     parameters: [ ]
     csrf_enabled: false
 
 api_list_issuefields:
     route: /api/:api_username/list/issuefields/for/:project_key/type/:issuetype/:format
-    module: remote
+    module: api
     action: listIssuefields
     parameters: [ ]
     csrf_enabled: false
 
 api_list_fieldvalues:
     route: '/api/:api_username/list/fieldvalues/for/field/:field_key/:format/*'
-    module: remote
+    module: api
     action: listFieldvalues
     parameters: [ ]
     csrf_enabled: false

--- a/configuration/routes.yml
+++ b/configuration/routes.yml
@@ -26,6 +26,13 @@ api_list_projects:
     parameters: [ ]
     csrf_enabled: false
 
+api_project:
+    route: /api/:api_username/projects/:project_key
+    module: api
+    action: project
+    parameters: [ ]
+    csrf_enabled: false
+
 api_list_issuetypes:
     route: /api/:api_username/issuetypes
     module: api

--- a/controllers/Main.php
+++ b/controllers/Main.php
@@ -271,4 +271,26 @@ class Main extends framework\Action
         $this->field_info = $return_array;
     }
 
+    public function runIssueEditTimeSpent(framework\Request $request)
+    {
+        try
+        {
+            \thebuggenie\core\framework\Context::performAction(
+                new \thebuggenie\core\modules\main\controllers\Main(),
+                'main',
+                'IssueEditTimeSpent'
+            );
+        }
+        catch (\Exception $e)
+        {
+            ob_get_clean();
+
+            return $this->renderJSON(array('edited' => 'error', 'error' => $e->getMessage()));
+        }
+
+        ob_get_clean();
+
+        $this->return_data = array('edited' => 'ok');
+    }
+
 }

--- a/controllers/Main.php
+++ b/controllers/Main.php
@@ -16,6 +16,14 @@ class Main extends framework\Action
 	protected static $_ver_api_mn = 0;
 	protected static $_ver_api_rev = 0;
 
+	/**
+	 * Decides whether to render details in single-entity endpoints.
+	 * (Set to false if the parameter "nodetail" is present in the request)
+	 * 
+	 * @var boolean $render_detail
+	 */
+	protected $render_detail = true;
+	
 	public function getApiVersion($with_revision = true)
 	{
 		$retvar = self::$_ver_api_mj . '.' . self::$_ver_api_mn;
@@ -73,6 +81,8 @@ class Main extends framework\Action
 
             if ($this->selected_project instanceof entities\Project)
                 framework\Context::setCurrentProject($this->selected_project);
+            
+            $this->render_detail = !isset($request['nodetail']);
         }
         catch (\Exception $e)
         {
@@ -136,7 +146,7 @@ class Main extends framework\Action
     }
     
     public function runMe(framework\Request $request) {
-        $this->users = array(framework\Context::getUser()->toJSON(true));
+        $this->users = array(framework\Context::getUser()->toJSON($this->render_detail));
     }
 
     public function runListProjects(framework\Request $request)
@@ -151,6 +161,16 @@ class Main extends framework\Action
         }
 
         $this->projects = $return_array;
+    }
+    
+    public function runProject(framework\Request $request) {
+        // Project is already selected in preExecute, so we just display it
+        if($this->selected_project instanceof entities\Project) {
+            $this->projects = array($this->selected_project->toJSON($this->render_detail));
+        } else {
+            $this->getResponse()->setHttpStatus(404);
+            return $this->renderJSON(array('error' => 'Project not found'));
+        }
     }
 
     public function runListIssuefields(framework\Request $request)

--- a/controllers/Main.php
+++ b/controllers/Main.php
@@ -147,7 +147,7 @@ class Main extends framework\Action
         foreach ($projects as $project)
         {
             if ($project->isDeleted()) continue;
-            $return_array[] = $project->toJSON();
+            $return_array[] = $project->toJSON(false);
         }
 
         $this->projects = $return_array;

--- a/controllers/Main.php
+++ b/controllers/Main.php
@@ -61,6 +61,11 @@ class Main extends framework\Action
     {
         try
         {
+            // Default to JSON if nothing is specified.
+            $newFormat = $request->getParameter('format', 'json');
+            $this->getResponse()->setTemplate(mb_strtolower($action) . '.' . $newFormat . '.php');
+            $this->getResponse()->setupResponseContentType($newFormat);
+            
             if ($project_key = $request['project_key'])
                 $this->selected_project = entities\Project::getByKey($project_key);
             elseif ($project_id = (int) $request['project_id'])
@@ -71,10 +76,17 @@ class Main extends framework\Action
         }
         catch (\Exception $e)
         {
-
+            $this->getResponse()->setHttpStatus(500);
+            return $this->renderJSON(array('error' => 'An exception occurred: ' . $e));
         }
     }
 
+    /**
+     * Authenticate an application using a one-time application password.
+     * Creates a token to be used for subsequent requests.
+     * 
+     * @param framework\Request $request
+     */
     public function runAuthenticate(framework\Request $request)
     {
         $username = trim($request['username']);

--- a/controllers/Main.php
+++ b/controllers/Main.php
@@ -220,7 +220,7 @@ class Main extends framework\Action
                     $choices = $classname::getAll();
                     foreach ($choices as $choice_key => $choice)
                     {
-                        $return_array['choices'][] = array('key' => $choice_key, 'name' => $choice->getName());
+                        $return_array['choices'][] = $choice->toJSON(true);
                     }
                     break;
                 case 'activitytype':
@@ -231,13 +231,13 @@ class Main extends framework\Action
                     $choices = $classname::getAll();
                     foreach ($choices as $choice_key => $choice)
                     {
-                        $return_array['choices'][] = array('key' => $choice_key, 'name' => $choice->getName());
+                        $return_array['choices'][] = $choice->toJSON(true);
                     }
                     break;
                 case 'percent_complete':
                     $return_array['description'] = framework\Context::getI18n()->__('Value of percentage completed');
                     $return_array['type'] = 'choice';
-                    $return_array['choices'][] = "1-100%";
+                    $return_array['choices'][] = "1-100%"; //TODO: That does not seem useful...
                     break;
                 case 'owner':
                 case 'assignee':
@@ -257,7 +257,7 @@ class Main extends framework\Action
                         $milestones = $this->selected_project->getAvailableMilestones();
                         foreach ($milestones as $milestone)
                         {
-                            $return_array['choices'][] = array('key' => $milestone->getID(), 'name' => $milestone->getName());
+                            $return_array['choices'][] = $milestone->toJSON(false);// array('key' => $milestone->getID(), 'name' => $milestone->getName());
                         }
                     }
                     break;

--- a/templates/listissuefields.json.php
+++ b/templates/listissuefields.json.php
@@ -1,0 +1,3 @@
+<?php
+
+    echo json_encode(array('count' => count($issuefields), 'issuefields' => $issuefields));

--- a/templates/listissuetypes.json.php
+++ b/templates/listissuetypes.json.php
@@ -1,3 +1,3 @@
 <?php
 
-    echo json_encode($issuetypes);
+    echo json_encode(array('count' => count($issuetypes), 'issuetypes' => $issuetypes));

--- a/templates/listprojects.json.php
+++ b/templates/listprojects.json.php
@@ -1,3 +1,3 @@
 <?php
 
-    echo json_encode($projects);
+    echo json_encode(array('count' => count($projects), 'projects' => $projects));

--- a/templates/me.json.php
+++ b/templates/me.json.php
@@ -1,0 +1,3 @@
+<?php
+
+    echo json_encode($users[0]);

--- a/templates/project.json.php
+++ b/templates/project.json.php
@@ -1,0 +1,3 @@
+<?php
+
+    echo json_encode($projects[0]);

--- a/templates/status.json.php
+++ b/templates/status.json.php
@@ -1,0 +1,3 @@
+<?php
+
+    echo json_encode($status_info);


### PR DESCRIPTION
Currently:
- re-did the changes from before extraction + applied them on @Premke's fixes for new module name
- Default to json format & remove that pesky :format parameter from the routes
- More actual usage of the toJSON functions
- Adds the optional parameter 'nodetail' that disables detailed information on certain endpoints.
- Adds an endpoint to display a single project. (/api/:api_username/projects/:project_key)
