### PR TITLE
Reworked method that logs issue time spent

### DIFF
--- a/Api.php
+++ b/Api.php
@@ -8,7 +8,7 @@
      * The Bug Genie API module
      *
      * @author
-     * @version 0.1
+     * @version 0.2
      * @license http://opensource.org/licenses/MPL-2.0 Mozilla Public License 2.0 (MPL 2.0)
      * @package thebuggenie/modules/api
      * @subpackage core
@@ -25,7 +25,7 @@
     class Api extends \thebuggenie\core\entities\Module
     {
 
-        const VERSION = '0.1';
+        const VERSION = '0.2';
 
         protected $_name = 'api';
         protected $_longname = 'External API module';

--- a/cli/ListFieldvalues.php
+++ b/cli/ListFieldvalues.php
@@ -57,9 +57,20 @@
                         $this->cliEcho("Available values:\n", 'white', 'bold');
                         if (count($response->choices))
                         {
+                            $this->cliEcho("value_key", 'yellow', 'bold');
+                            $this->cliEcho(" - value name\n", 'white', 'bold');
+
                             foreach ($response->choices as $value)
                             {
-                                $this->cliEcho("  {$value}\n", 'yellow');
+                                if (is_object($value))
+                                {
+                                    $this->cliEcho($value->key, 'yellow');
+                                    $this->cliEcho(" - $value->name\n");
+                                }
+                                else if (is_string($value))
+                                {
+                                    $this->cliEcho("  {$value}\n", 'yellow');
+                                }
                             }
                         }
                         else

--- a/cli/ListIssues.php
+++ b/cli/ListIssues.php
@@ -59,7 +59,7 @@
 
             $options['project_key'] = $this->getProvidedArgument('project_key');
 
-            $response = $this->getRemoteResponse($this->getRemoteURL('project_list_issues', $options));
+            $response = $this->getRemoteResponse($this->getRemoteURL('api_list_issues', $options));
 
             $this->cliEcho("\n");
             if (!empty($response) && $response->count > 0)
@@ -81,12 +81,12 @@
                     if ($this->getProvidedArgument('detailed', 'no') == 'yes')
                     {
                         $this->cliEcho("Posted: ", 'blue', 'bold');
-                        $this->cliEcho(tbg_formatTime($issue->created_at, 21));
+                        $this->cliEcho(tbg_formatTime($issue->created_at, 21, true, true));
                         $this->cliEcho(" by ");
                         $this->cliEcho($issue->posted_by, 'cyan');
                         $this->cliEcho("\n");
                         $this->cliEcho("Updated: ", 'blue', 'bold');
-                        $this->cliEcho(tbg_formatTime($issue->last_updated, 21));
+                        $this->cliEcho(tbg_formatTime($issue->last_updated, 21, true, true));
                         $this->cliEcho("\n");
                         $this->cliEcho("Assigned to: ", 'blue', 'bold');
                         $this->cliEcho($issue->assigned_to, 'yellow', 'bold');

--- a/cli/ListIssuetypes.php
+++ b/cli/ListIssuetypes.php
@@ -40,8 +40,15 @@
             {
                 $this->cliEcho("issuetype_key", 'yellow', 'bold');
                 $this->cliEcho(" - Description\n", 'white', 'bold');
-                foreach ($response as $key => $issuetype)
+                $issuetypes = isset($response->issuetypes) ? $response->issuetypes : $response;
+                foreach ($issuetypes as $key => $issuetype)
                 {
+                    if (is_object($issuetype))
+                    {
+                        $key = $issuetype->key;
+                        $issuetype = $issuetype->name;
+                    }
+
                     $this->cliEcho("$key", 'yellow');
                     $this->cliEcho(" - $issuetype\n");
                 }

--- a/cli/ListProjects.php
+++ b/cli/ListProjects.php
@@ -40,8 +40,15 @@
             {
                 $this->cliEcho("project_key", 'green', 'bold');
                 $this->cliEcho(" - project name\n", 'white', 'bold');
-                foreach ($response as $project_key => $project_name)
+                $projects = isset($response->projects) ? $response->projects : $response;
+                foreach ($projects as $project_key => $project_name)
                 {
+                    if (is_object($project_name))
+                    {
+                        $project_key = $project_name->key;
+                        $project_name = $project_name->name;
+                    }
+
                     $this->cliEcho($project_key, 'green');
                     $this->cliEcho(" - $project_name\n");
                 }

--- a/cli/ListWorkflowTransitions.php
+++ b/cli/ListWorkflowTransitions.php
@@ -59,7 +59,7 @@
             }
 
             $url_options = array('project_key' => $this->project_key, 'issue_no' => $this->issue_number, 'format' => 'json');
-            $response = $this->getRemoteResponse($this->getRemoteURL('project_list_workflowtransitions', $url_options));
+            $response = $this->getRemoteResponse($this->getRemoteURL('api_list_workflowtransitions', $url_options));
             $this->cliEcho("\n");
 
             if (!$transition)

--- a/cli/ShowIssue.php
+++ b/cli/ShowIssue.php
@@ -50,8 +50,8 @@
             $url_options = array('project_key' => $this->project_key, 'issue_no' => $this->issue_number, 'format' => 'json');
 
             $this->cliEcho("\n");
-            
-            $issue = $this->getRemoteResponse($this->getRemoteURL('viewissue', $url_options));
+
+            $issue = $this->getRemoteResponse($this->getRemoteURL('api_viewissue', $url_options));
 
             \thebuggenie\core\framework\Context::loadLibrary('common');
             $this->cliEcho($print_issue_number, 'green', 'bold');
@@ -64,7 +64,7 @@
             $this->cliEcho($state);
             $this->cliEcho("\n");
             $this->cliEcho("Posted: ", 'white', 'bold');
-            $this->cliEcho(tbg_formatTime($issue->created_at, 21) . ' (' . $issue->created_at . ')');
+            $this->cliEcho(tbg_formatTime($issue->created_at, 21, true, true) . ' (' . $issue->created_at . ')');
             $this->cliEcho("\n");
             $this->cliEcho("Posted by: ", 'white', 'bold');
 
@@ -75,7 +75,7 @@
 
             $this->cliEcho("\n");
             $this->cliEcho("Updated: ", 'white', 'bold');
-            $this->cliEcho(tbg_formatTime($issue->updated_at, 21) . ' (' . $issue->updated_at . ')');
+            $this->cliEcho(tbg_formatTime($issue->updated_at, 21, true, true) . ' (' . $issue->updated_at . ')');
             $this->cliEcho("\n");
             $this->cliEcho("Assigned to: ", 'white', 'bold');
 
@@ -98,7 +98,7 @@
             {
                 $name = ucfirst(str_replace('_', ' ', $field));                
                 $this->cliEcho("{$name}: ", 'white', 'bold');
-                if ($issue->$field)
+                if (isset($issue->$field))
                 {
                     if ($field == 'estimated_time' || $field == 'spent_time')
                     {
@@ -143,7 +143,7 @@
                         
                         $this->cliEcho("\n");
                         $this->cliEcho('Posted: ', 'white', 'bold');
-                        $this->cliEcho(tbg_formatTime($comment->created_at, 21) . ' (' . $comment->created_at . ')');
+                        $this->cliEcho(tbg_formatTime($comment->created_at, 21, true, true) . ' (' . $comment->created_at . ')');
                         $this->cliEcho("\n");
                         $this->cliEcho('Comment: ', 'white', 'bold');
                         $this->cliEcho($comment->content);

--- a/cli/UpdateIssue.php
+++ b/cli/UpdateIssue.php
@@ -98,7 +98,7 @@
 
             if (count($fields) || array_key_exists('workflow_transition', $url_options))
             {
-                $response = $this->getRemoteResponse($this->getRemoteURL('project_update_issuedetails', $url_options), $post_data);
+                $response = $this->getRemoteResponse($this->getRemoteURL('api_update_issuedetails', $url_options), $post_data);
 
                 if (!is_object($response))
                     throw new \Exception('Could not parse the return value from the server. Please re-check the command run.');

--- a/configuration/routes.yml
+++ b/configuration/routes.yml
@@ -41,22 +41,50 @@ api_list_issuetypes:
     csrf_enabled: false
 
 api_list_issuefields:
-    route: /api/:api_username/list/issuefields/for/:project_key/type/:issuetype
+    route: /api/:api_username/list/issuefields/for/:project_key/type/:issuetype/:format
     module: api
-    action: listIssuefields
+    action: Project::listIssuefields
     parameters: [ ]
     csrf_enabled: false
 
 api_list_fieldvalues:
-    route: '/api/:api_username/list/fieldvalues/for/field/:field_key/*'
+    route: '/api/:api_username/list/fieldvalues/for/field/:field_key/:format/*'
     module: api
     action: listFieldvalues
     parameters: [ ]
     csrf_enabled: false
 
 api_issue_edittimespent:
-    route: /api/:api_username/:project_key/issues/:issue_id/timespent/:entry_id
+    route: /api/:api_username/:project_key/issues/:issue_id/timespent/:entry_id/:format
     module: api
-    action: issueEditTimeSpent
+    action: Project::issueEditTimeSpent
+    parameters: [ ]
+    csrf_enabled: false
+
+api_list_issues:
+    route: '/api/:api_username/issues/:project_key/:format/*'
+    module: api
+    action: Project::listIssues
+    parameters: [ ]
+    csrf_enabled: false
+
+api_list_workflowtransitions:
+    route: '/api/:api_username/workflowtransitions/:project_key/:issue_no/:format/*'
+    module: api
+    action: Project::listWorkflowTransitions
+    parameters: [ ]
+    csrf_enabled: false
+
+api_viewissue:
+    route: '/api/:api_username/issue/:project_key/:issue_no/*'
+    module: api
+    action: Project::viewIssue
+    parameters: [ ]
+    csrf_enabled: false
+
+api_update_issuedetails:
+    route: '/api/:api_username/update/issue/:issue_no/:format/*'
+    module: api
+    action: Project::updateIssueDetails
     parameters: [ ]
     csrf_enabled: false

--- a/controllers/Main.php
+++ b/controllers/Main.php
@@ -226,7 +226,7 @@ class Main extends framework\Action
             }
 
             framework\Context::loadLibrary('common');
-            $spenttime->editOrAdd($issue, $this->getUser(), array_only_with_default($request->getParameters(), array_merge(array('timespent_manual', 'timespent_specified_type', 'timespent_specified_value', 'timespent_activitytype', 'timespent_comment'), \thebuggenie\core\entities\common\Timeable::$units)));
+            $spenttime->editOrAdd($issue, $this->getUser(), array_only_with_default($request->getParameters(), array_merge(array('timespent_manual', 'timespent_specified_type', 'timespent_specified_value', 'timespent_activitytype', 'timespent_comment'), \thebuggenie\core\entities\common\Timeable::getUnitsWithPoints())));
         }
         catch (\Exception $e)
         {

--- a/controllers/Main.php
+++ b/controllers/Main.php
@@ -226,7 +226,7 @@ class Main extends framework\Action
             }
 
             framework\Context::loadLibrary('common');
-            $spenttime->editOrAdd($issue, $this->getUser(), array_only_with_default($request->getParameters(), array_merge(array('timespent_manual', 'timespent_specified_type', 'timespent_specified_value', 'timespent_activitytype', 'timespent_comment'), \thebuggenie\core\entities\common\Timeable::getUnitsWithPoints())));
+            $spenttime->editOrAdd($issue, $this->getUser(), array_only_with_default($request->getParameters(), array_merge(array('timespent_manual', 'timespent_specified_type', 'timespent_specified_value', 'timespent_activitytype', 'timespent_comment', 'edited_at'), \thebuggenie\core\entities\common\Timeable::getUnitsWithPoints())));
         }
         catch (\Exception $e)
         {

--- a/controllers/Main.php
+++ b/controllers/Main.php
@@ -13,7 +13,7 @@ class Main extends framework\Action
 {
 
 	protected static $_ver_api_mj = 1;
-	protected static $_ver_api_mn = 0;
+	protected static $_ver_api_mn = 1;
 	protected static $_ver_api_rev = 0;
 
 	/**
@@ -173,30 +173,6 @@ class Main extends framework\Action
         }
     }
 
-    public function runListIssuefields(framework\Request $request)
-    {
-        try
-        {
-            $issuetype = entities\Issuetype::getByKeyish($request['issuetype']);
-
-            if ($issuetype instanceof entities\common\Identifiable)
-            {
-                $issuefields = $this->selected_project->getVisibleFieldsArray($issuetype->getID());
-            }
-            else
-            {
-                $issuefields = array();
-            }
-        }
-        catch (\Exception $e)
-        {
-            $this->getResponse()->setHttpStatus(400);
-            return $this->renderJSON(array('error' => 'An exception occurred: ' . $e));
-        }
-
-        $this->issuefields = array_keys($issuefields);
-    }
-
     public function runListIssuetypes(framework\Request $request)
     {
         $issuetypes = entities\Issuetype::getAll();
@@ -289,34 +265,6 @@ class Main extends framework\Action
         }
 
         $this->field_info = $return_array;
-    }
-
-    public function runIssueEditTimeSpent(framework\Request $request)
-    {
-        try
-        {
-            $entry_id = $request['entry_id'];
-            $spenttime = ($entry_id) ? tables\IssueSpentTimes::getTable()->selectById($entry_id) : new entities\IssueSpentTime();
-
-            if ($issue_id = $request['issue_id'])
-            {
-                $issue = entities\Issue::getB2DBTable()->selectById($issue_id);
-            }
-            else
-            {
-                throw new \Exception('no issue');
-            }
-
-            framework\Context::loadLibrary('common');
-            $spenttime->editOrAdd($issue, $this->getUser(), array_only_with_default($request->getParameters(), array_merge(array('timespent_manual', 'timespent_specified_type', 'timespent_specified_value', 'timespent_activitytype', 'timespent_comment', 'edited_at'), \thebuggenie\core\entities\common\Timeable::getUnitsWithPoints())));
-        }
-        catch (\Exception $e)
-        {
-            $this->getResponse()->setHttpStatus(400);
-            return $this->renderJSON(array('edited' => 'error', 'error' => $e->getMessage()));
-        }
-
-        $this->return_data = array('edited' => 'ok');
     }
 
 }

--- a/controllers/Main.php
+++ b/controllers/Main.php
@@ -225,43 +225,8 @@ class Main extends framework\Action
                 throw new \Exception('no issue');
             }
 
-            if (!$spenttime->getID())
-            {
-                if ($request['timespent_manual'])
-                {
-                    $times = entities\Issue::convertFancyStringToTime($request['timespent_manual'], $issue);
-                }
-                else
-                {
-                    $times = \thebuggenie\core\entities\common\Timeable::getZeroedUnitsWithPoints();
-                    $times[$request['timespent_specified_type']] = $request['timespent_specified_value'];
-                }
-                $spenttime->setIssue($issue);
-                $spenttime->setUser($this->getUser());
-            }
-            else
-            {
-                $times = array('points' => $request['points'],
-                    'minutes' => $request['minutes'],
-                    'hours' => $request['hours'],
-                    'days' => $request['days'],
-                    'weeks' => $request['weeks'],
-                    'months' => $request['months']);
-                $edited_at = $request['edited_at'];
-                $spenttime->setEditedAt(mktime(0, 0, 1, $edited_at['month'], $edited_at['day'], $edited_at['year']));
-            }
-            $times['hours'] *= 100;
-            $spenttime->setSpentPoints($times['points']);
-            $spenttime->setSpentMinutes($times['minutes']);
-            $spenttime->setSpentHours($times['hours']);
-            $spenttime->setSpentDays($times['days']);
-            $spenttime->setSpentWeeks($times['weeks']);
-            $spenttime->setSpentMonths($times['months']);
-            $spenttime->setActivityType($request['timespent_activitytype']);
-            $spenttime->setComment($request['timespent_comment']);
-            $spenttime->save();
-
-            $spenttime->getIssue()->saveSpentTime();
+            framework\Context::loadLibrary('common');
+            $spenttime->editOrAdd($issue, $this->getUser(), array_only_with_default($request->getParameters(), array_merge(array('timespent_manual', 'timespent_specified_type', 'timespent_specified_value', 'timespent_activitytype', 'timespent_comment'), \thebuggenie\core\entities\common\Timeable::$units)));
         }
         catch (\Exception $e)
         {

--- a/controllers/Project.php
+++ b/controllers/Project.php
@@ -13,6 +13,32 @@ use thebuggenie\core\framework,
 class Project extends helpers\ProjectActions
 {
 
+    /**
+     * The currently selected project in actions where there is one
+     *
+     * @access protected
+     * @property entities\Project $selected_project
+     */
+    public function preExecute(framework\Request $request, $action)
+    {
+        parent::preExecute($request, $action);
+
+        try
+        {
+            // Default to JSON if nothing is specified.
+            $newFormat = $request->getParameter('format', 'json');
+            $this->getResponse()->setTemplate(mb_strtolower($action) . '.' . $newFormat . '.php');
+            $this->getResponse()->setupResponseContentType($newFormat);
+
+            $this->render_detail = !isset($request['nodetail']);
+        }
+        catch (\Exception $e)
+        {
+            $this->getResponse()->setHttpStatus(500);
+            return $this->renderJSON(array('error' => 'An exception occurred: ' . $e));
+        }
+    }
+
     public function runListIssuefields(framework\Request $request)
     {
         try

--- a/controllers/Project.php
+++ b/controllers/Project.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace thebuggenie\modules\api\controllers;
+
+use thebuggenie\core\framework,
+    thebuggenie\core\entities,
+    thebuggenie\core\entities\tables,
+    thebuggenie\core\helpers;
+
+/**
+ * actions for the api module
+ */
+class Project extends helpers\ProjectActions
+{
+
+    public function runListIssuefields(framework\Request $request)
+    {
+        try
+        {
+            $issuetype = entities\Issuetype::getByKeyish($request['issuetype']);
+
+            if ($issuetype instanceof entities\common\Identifiable)
+            {
+                $issuefields = $this->selected_project->getVisibleFieldsArray($issuetype->getID());
+            }
+            else
+            {
+                $issuefields = array();
+            }
+        }
+        catch (\Exception $e)
+        {
+            $this->getResponse()->setHttpStatus(400);
+            return $this->renderJSON(array('error' => 'An exception occurred: ' . $e));
+        }
+
+        $this->issuefields = array_keys($issuefields);
+    }
+
+    public function runIssueEditTimeSpent(framework\Request $request)
+    {
+        try
+        {
+            $entry_id = $request['entry_id'];
+            $spenttime = ($entry_id) ? tables\IssueSpentTimes::getTable()->selectById($entry_id) : new entities\IssueSpentTime();
+
+            if ($issue_id = $request['issue_id'])
+            {
+                $issue = entities\Issue::getB2DBTable()->selectById($issue_id);
+            }
+            else
+            {
+                throw new \Exception('no issue');
+            }
+
+            framework\Context::loadLibrary('common');
+            $spenttime->editOrAdd($issue, $this->getUser(), array_only_with_default($request->getParameters(), array_merge(array('timespent_manual', 'timespent_specified_type', 'timespent_specified_value', 'timespent_activitytype', 'timespent_comment', 'edited_at'), \thebuggenie\core\entities\common\Timeable::getUnitsWithPoints())));
+        }
+        catch (\Exception $e)
+        {
+            $this->getResponse()->setHttpStatus(400);
+            return $this->renderJSON(array('edited' => 'error', 'error' => $e->getMessage()));
+        }
+
+        $this->return_data = array('edited' => 'ok');
+    }
+
+
+}

--- a/templates/listissues.json.php
+++ b/templates/listissues.json.php
@@ -1,0 +1,22 @@
+<?php
+
+    if ($count > 0)
+    {
+        foreach ($issues as $issue)
+        {
+            if (! $issue->hasAccess()) continue;
+
+            $return_issues[] = array('id' => $issue->getID(),
+                'title' => $issue->getRawTitle(),
+                'state' => $issue->getState(),
+                'issue_no' => $issue->getFormattedIssueNo(true, true),
+                'posted_by' => ($issue->getPostedBy() instanceof \thebuggenie\core\entities\common\Identifiable) ? $issue->getPostedBy()->getUsername() : __('Unknown'),
+                'assigned_to' => ($issue->getAssignee() instanceof \thebuggenie\core\entities\common\Identifiable) ? $issue->getAssignee()->getName() : __('Noone'),
+                'created_at' => $issue->getPosted(),
+                'status' => ($issue->getStatus() instanceof \thebuggenie\core\entities\Status) ? $issue->getStatus()->getName() : __('Unknown'),
+                'last_updated' => $issue->getLastUpdatedTime()
+            );
+        }
+    }
+
+    echo json_encode(array('count' => $count, 'issues' => $return_issues));

--- a/templates/listissues.json.php
+++ b/templates/listissues.json.php
@@ -6,16 +6,7 @@
         {
             if (! $issue->hasAccess()) continue;
 
-            $return_issues[] = array('id' => $issue->getID(),
-                'title' => $issue->getRawTitle(),
-                'state' => $issue->getState(),
-                'issue_no' => $issue->getFormattedIssueNo(true, true),
-                'posted_by' => ($issue->getPostedBy() instanceof \thebuggenie\core\entities\common\Identifiable) ? $issue->getPostedBy()->getUsername() : __('Unknown'),
-                'assigned_to' => ($issue->getAssignee() instanceof \thebuggenie\core\entities\common\Identifiable) ? $issue->getAssignee()->getName() : __('Noone'),
-                'created_at' => $issue->getPosted(),
-                'status' => ($issue->getStatus() instanceof \thebuggenie\core\entities\Status) ? $issue->getStatus()->getName() : __('Unknown'),
-                'last_updated' => $issue->getLastUpdatedTime()
-            );
+            $return_issues[] = $issue->toJSON(true);
         }
     }
 

--- a/templates/listworkflowtransitions.json.php
+++ b/templates/listworkflowtransitions.json.php
@@ -1,0 +1,3 @@
+<?php
+
+    echo json_encode($transitions);

--- a/templates/viewissue.json.php
+++ b/templates/viewissue.json.php
@@ -1,0 +1,3 @@
+<?php
+
+    echo json_encode($issue->toJSON());


### PR DESCRIPTION
Logic for logging issue spent time is now separated from interface which brings new questions:
Should we keep logic for functionalities same both in interface and api? How?

I think logic shouldn't differ from interface and api since contributor could forget to apply modifications on both places. Should we abstract logic somewhere? Perhaps to entities methods?

This concerns further development when mirroring functionalities from interface to api, so @founderio I would like your opinion as well.
