### PR TITLE
Adjust /api/authenticate endpoint according thebuggenie/thebuggenie#464

### DIFF
--- a/controllers/Main.php
+++ b/controllers/Main.php
@@ -99,6 +99,8 @@ class Main extends framework\Action
      */
     public function runAuthenticate(framework\Request $request)
     {
+        framework\Logging::log('Authenticating new application password.', 'api', framework\Logging::LEVEL_INFO);
+
         $username = trim($request['username']);
         $password = trim($request['password']);
         if ($username)
@@ -106,19 +108,25 @@ class Main extends framework\Action
             $user = tables\Users::getTable()->getByUsername($username);
             if ($password && $user instanceof entities\User)
             {
+                // Generate token from the application password
+                $token = entities\ApplicationPassword::createToken($password);
+                // Crypt, for comparison with db value
+                $hashed_token = entities\User::hashPassword($token, $user->getSalt());
                 foreach ($user->getApplicationPasswords() as $app_password)
                 {
+                    // Only return the token for new application passwords!
                     if (!$app_password->isUsed())
                     {
-                        if ($app_password->getHashPassword() == entities\User::hashPassword($password, $user->getSalt()))
+                        if ($app_password->getHashPassword() == $hashed_token)
                         {
                             $app_password->useOnce();
                             $app_password->save();
-                            return $this->renderJSON(array('token' => $app_password->getHashPassword()));
+                            return $this->renderJSON(array('token' => $token, 'name' => $app_password->getName(), 'created_at' => $app_password->getCreatedAt()));
                         }
                     }
                 }
             }
+            framework\Logging::log('No password matched.', 'api', framework\Logging::LEVEL_INFO);
         }
 
         $this->getResponse()->setHttpStatus(400);


### PR DESCRIPTION
Adjust /api/authenticate endpoint according thebuggenie/thebuggenie#464

As in:
- Take visible, one-time password & create token
- Find matching, unused application password
- Mark password as used & send token to client for subsequent authentication
